### PR TITLE
fix: YT Spend by region API

### DIFF
--- a/blueprints/google_dashboard/queries.py
+++ b/blueprints/google_dashboard/queries.py
@@ -354,13 +354,26 @@ def spend_of_advertiser_by_region(
 
     earliest_date_after_start_date = session.query(
         db.func.min(models.AdvertiserRegionalSpend.report_date)
-    ).filter(models.AdvertiserRegionalSpend.report_date >= start_date)
+    ).join(
+        models.AdvertiserStat,
+        models.AdvertiserRegionalSpend.advertiser_id
+        == models.AdvertiserStat.advertiser_id
+    ).filter(
+        models.AdvertiserRegionalSpend.report_date >= start_date,
+        models.AdvertiserStat.advertiser_name == advertiser_name
+    )
     earliest_date_after_start_date_sq = earliest_date_after_start_date.subquery(
         "earliest_date_after_start_date"
     )
     latest_date_before_end_date = session.query(
         db.func.max(models.AdvertiserRegionalSpend.report_date)
-    ).filter(models.AdvertiserRegionalSpend.report_date <= end_date)
+    ).join(
+        models.AdvertiserStat,
+        models.AdvertiserRegionalSpend.advertiser_id == models.AdvertiserStat.advertiser_id
+    ).filter(
+        models.AdvertiserRegionalSpend.report_date <= end_date,
+        models.AdvertiserStat.advertiser_name == advertiser_name
+    )
     latest_date_before_end_date_sq = latest_date_before_end_date.subquery(
         "latest_date_before_end_date"
     )


### PR DESCRIPTION
- fixing filter querying for max and min date by advertiser_id