### PR TITLE
Change DC region name in data/regions.json

### DIFF
--- a/data/regions.json
+++ b/data/regions.json
@@ -44,10 +44,6 @@
     "value": "Washington, District of Columbia"
   },
   {
-    "label": "Federated States Of Micronesia",
-    "value": "Federated States Of Micronesia"
-  },
-  {
     "label": "Florida",
     "value": "Florida"
   },
@@ -174,10 +170,6 @@
   {
     "label": "Oregon",
     "value": "Oregon"
-  },
-  {
-    "label": "Palau",
-    "value": "Palau"
   },
   {
     "label": "Pennsylvania",

--- a/data/regions.json
+++ b/data/regions.json
@@ -40,8 +40,8 @@
     "value": "Delaware"
   },
   {
-    "label": "District Of Columbia",
-    "value": "District Of Columbia"
+    "label": "Washington, District of Columbia",
+    "value": "Washington, District of Columbia"
   },
   {
     "label": "Federated States Of Micronesia",


### PR DESCRIPTION
data uses 'Washington, District of Columbia' for DC region name